### PR TITLE
Fixed app SERVER_NAME issue using url_for outside scope

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,7 +1,7 @@
-from flask import render_template, Markup, send_from_directory, url_for, redirect, session, request, g, abort, current_app
+from flask import render_template, Markup, send_from_directory, url_for, session, request, g, abort, current_app
 from elasticsearch_dsl.connections import connections
 from elasticsearch_dsl import Search
-from src.config.config import base_path, dir_breaks, SECRET_KEY, recent_topic_len, es_host, es_port, flask_hostname, flask_port, root_web_path
+from src.config.config import base_path, dir_breaks, SECRET_KEY, recent_topic_len, es_host, es_port, flask_hostname, flask_port, root_web_path, file_upload_path
 from src.topics import topics, folder_group, file_group
 from src.elastic.setup import ElasticSettings
 from src.elastic.sync import sync_elastic
@@ -26,14 +26,12 @@ def start_flask(debug=False):
     '''
     app = current_app._get_current_object()
     app.secret_key = SECRET_KEY
-    # localhost as Servername hack to serve ip addresses aswell
-    app.config['SERVER_NAME'] = 'localhost' + ':' + str(flask_port)
     app.static_folder = 'src/static'
     app.template_folder = 'src/templates'
     app.before_first_request(bef_first_request)
     app.before_request(before_request)
     app.add_url_rule(root_web_path, 'home', home)
-    app.add_url_rule(root_web_path + 'fakeUpload/<path:file_and_path>', 'get_local_file', get_local_file)
+    app.add_url_rule(root_web_path + file_upload_path + '/<path:file_and_path>', 'get_local_file', get_local_file)
     app.add_url_rule(root_web_path + 'fakeEmbed/<path:file_and_path>', 'get_embed_file', get_embed_file)
     app.add_url_rule(root_web_path + 'Settings', 'settings', settings, methods=['POST', 'GET'])
     app.add_url_rule(root_web_path + '<path:subpath>', 'sub_pages', sub_pages)

--- a/src/config/config.py.example
+++ b/src/config/config.py.example
@@ -27,6 +27,10 @@ flask_port = 5000
 # e.g. root_web_path = '/docfex/' (Note: ending / is mandatory)
 root_web_path = '/'
 
+# url addition to upload files on the OS
+# Note: don't add / at start or end!
+file_upload_path = 'fakeUpload'
+
 # Secret key flask uses for session cookies
 SECRET_KEY = r'<generate e.g. with "os.urandom(24)>"'
 

--- a/src/md_convert.py
+++ b/src/md_convert.py
@@ -1,5 +1,4 @@
-from flask import url_for, current_app
-from src.config.config import base_path, dir_breaks
+from src.config.config import base_path, dir_breaks, root_web_path, file_upload_path
 import re
 import markdown
 
@@ -74,7 +73,8 @@ def link_images(base_html, filename):
     filename = '/'.join(filename.split('/')[:-1]).replace(dir_breaks, '/')
     for m in re.finditer(r'<img[\w\W]*?src=\"((?!(https=|ftp):)[\w\/.]+?)\"\s/>', base_html):
         web_filepath = filename + '/' + m.group(1)
-        data_link = url_for('get_local_file', file_and_path=web_filepath)
+        # url hardcoded since outside flask scope
+        data_link = root_web_path + file_upload_path + '/' + web_filepath
         bootified_html += base_html[last_found:m.start(1)] + data_link + base_html[m.end(1):m.end(0)]
         last_found = m.end(0)
         


### PR DESCRIPTION
url_for used inside md_convert.py was outside app scope of Flask resulting in Runtimeerror when not specifying SERVER_NAME in app.config

url is now hardcoded in md_convert.py to prevent the need to set SERVER_NAME, since SERVER_NAME has issues using only ip and no domain.