### PR TITLE
Handle tika exceptions

### DIFF
--- a/src/elastic/models/pdf.py
+++ b/src/elastic/models/pdf.py
@@ -95,13 +95,9 @@ class EsPdf(EsBase):
         try:
             created = self._own_doc.save(pipeline=pipe, ** kwargs)
         except TransportError:
-            enc_doc = AttachmentEncDoc(id=self.es_id, enc_attachment=base64.b64encode(b'indexing failed').decode('ascii'))
-            base_doc = PdfDoc(meta={'id': self.es_id}, name=self._own_obj.name,
-            web_path=self._own_obj.web_path, web_icon=self._own_obj.web_icon,
-            parent_path=self._own_obj.parent_path, encoded_obj=enc_doc,
-            last_modified=self._own_obj.last_modified, os_size=self._own_obj.os_size,
-            mimetype=self._own_obj.mimetype)
-            created = base_doc.save()
+            empty_enc_doc = AttachmentEncDoc(id=self.es_id, enc_attachment=base64.b64encode(b'indexing failed').decode('ascii'))
+            self._own_doc.encoded_obj = empty_enc_doc
+            created = self._own_doc.save()
 
         return created
 

--- a/src/elastic/models/pdf.py
+++ b/src/elastic/models/pdf.py
@@ -1,6 +1,7 @@
 from elasticsearch_dsl import Index, MetaField
 from .attachments import AttachmentDoc, AttachmentEncDoc, ingest_attachment, attachment_fields
 from .base import index_settings, EsBase, BaseDoc
+from elasticsearch import TransportError
 from src.config.config import web_icons
 import base64
 
@@ -88,7 +89,21 @@ class EsPdf(EsBase):
             parent_path=self._own_obj.parent_path, encoded_obj=enc_doc,
             last_modified=self._own_obj.last_modified, os_size=self._own_obj.os_size,
             mimetype=self._own_obj.mimetype)
-        return self._own_doc.save(pipeline=pipe, ** kwargs)
+        
+        # if pdf can't be read, index without content
+        created = False
+        try:
+            created = self._own_doc.save(pipeline=pipe, ** kwargs)
+        except TransportError:
+            enc_doc = AttachmentEncDoc(id=self.es_id, enc_attachment=base64.b64encode(b'indexing failed').decode('ascii'))
+            base_doc = PdfDoc(meta={'id': self.es_id}, name=self._own_obj.name,
+            web_path=self._own_obj.web_path, web_icon=self._own_obj.web_icon,
+            parent_path=self._own_obj.parent_path, encoded_obj=enc_doc,
+            last_modified=self._own_obj.last_modified, os_size=self._own_obj.os_size,
+            mimetype=self._own_obj.mimetype)
+            created = base_doc.save()
+
+        return created
 
     def get(self, _source_exclude=[], ** kwargs):
         '''


### PR DESCRIPTION
Some pdfs can not be read by tika (apache tika is used by elastic to read attachments/file content)
This results in a TransportError in docfex.

This is now catched and the file gets saved without its content.
The content of the file can't be searched, but at least it appears in the explorer.

Since markdown uses the same procedure, it was adapted for it aswell.