### PR TITLE
Fix startup exceptions

### DIFF
--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -14,7 +14,7 @@ Since docfex basically is a gateway between Flask and Elasticsearch, there is no
 
 **2. Logging**</br>
 Besides testing, logging should also be improved. 
-Currently information is simply outputted using print().
+Currently information is simply outputted to the root console using the base logger.
 
 
 **Note:** Until testing and logging is not improved, no other features are added!

--- a/main.py
+++ b/main.py
@@ -26,11 +26,11 @@ def start_elastic():
     '''
     Connects to elastic and creates a background job to kepp elastic and os in sync
     '''
-    client = setup_elastic()
+    setup_elastic()
     # omitting a trigger removes the job from the job pool, but interval trigger first waits for the interval to finish before execution
     # => using cron first, then reschedule to interval to start job immediately  
     es_sync_scheduler.add_job(sync_elastic, id=es_job_id,
-                              trigger='cron', second='*/10', kwargs={'es_client': client, 'app': app})
+                              trigger='cron', second='*/10', kwargs={'app': app})
     es_sync_scheduler.add_listener(job_end_listener, EVENT_JOB_EXECUTED | EVENT_JOB_ERROR)
     if not(es_sync_scheduler.running):
         es_sync_scheduler.start()

--- a/src/app.py
+++ b/src/app.py
@@ -13,6 +13,7 @@ from elasticsearch.exceptions import TransportError
 from urllib3.exceptions import NewConnectionError
 from functools import wraps
 from gevent.pywsgi import WSGIServer
+import logging
 import sys
 import re
 import os
@@ -184,7 +185,7 @@ def get_subpage(subpath):
         res = s[0].execute()
         return None if (res.hits.total == 0) else res.hits[0]
     except (TransportError, NewConnectionError, ConnectionRefusedError):
-        print('Can\'t connect to elastic from flask')
+        logging.critical('Can\'t connect to elastic from flask')
         sys.exit()
 
 

--- a/src/header.py
+++ b/src/header.py
@@ -5,8 +5,8 @@ class header:
     '''
     Gets all needed values that are displayed in the header section of the page
     '''
-    def __init__(self, es_client):
-        self.header_topics = topics.get_root_topiclist(es_client)
+    def __init__(self):
+        self.header_topics = topics.get_root_topiclist()
         self.cloud_storage_url = cloud_storage_url
         self.repo_url = repo_url
         self.notes_url = notes_url

--- a/src/search.py
+++ b/src/search.py
@@ -1,6 +1,6 @@
 from src.config.config import preview_len, file_group, folder_group, max_found_names, max_found_content
 from src.elastic.models.attachments import attachment_fields
-from .elastic.setup import get_es_indices
+from .elastic.setup import get_es_indices, es_client
 from flask import Markup, session
 from .models.web_file import web_file
 from .models.web_folder import web_folder
@@ -18,7 +18,7 @@ class SearchSettings:
         self.search_in_subfiles = search_in_subfiles
 
 
-def get_search_result(es_client, searchterm, search_type, search_path):
+def get_search_result(searchterm, search_type, search_path):
     '''
     Returns a list of hits from elastic that matched the searchterm
     '''
@@ -32,16 +32,16 @@ def get_search_result(es_client, searchterm, search_type, search_path):
     found_terms = {}
     exclude_fields = attachment_fields[:]
     exclude_fields.append('saved_md')
-    _search_file_foldername(es_client, searchterm, found_terms, filter_q, exclude_fields)
+    _search_file_foldername(searchterm, found_terms, filter_q, exclude_fields)
     if (session['settings']['global_search_in_files']) or (search_type == file_group) \
             or ((search_type == folder_group) and (session['settings']['search_in_subfiles'])):
         
-        _search_in_files(es_client, searchterm, found_terms, filter_q, exclude_fields)
+        _search_in_files(searchterm, found_terms, filter_q, exclude_fields)
     
     return found_terms
 
 
-def _search_file_foldername(es_client, searchterm, found_terms, filter_query, exclude_fields):
+def _search_file_foldername(searchterm, found_terms, filter_query, exclude_fields):
     '''
     Searches only for file/foldernames that match the searchterm
     '''
@@ -66,7 +66,7 @@ def _search_file_foldername(es_client, searchterm, found_terms, filter_query, ex
             found_terms[file_group].append(wf)
 
 
-def _search_in_files(es_client, searchterm, found_terms, filter_query, exclude_fields):
+def _search_in_files(searchterm, found_terms, filter_query, exclude_fields):
     '''
     Searches the searchterm inside supported text files
     '''


### PR DESCRIPTION
Elasticsearch was filling stdout with connection exceptions, even when catching them.
To resolve that, the log level for elasticsearch is set to ERROR until first connection to elastic is set.
Then it gets set back to WARNING.

**While fixing the above issue, two major changes were made:**</br>
1. Combined all modules to only use one client connection to elastic
Before one client was created handling the synchronisation, and another one used by flask.
For easier management of the connection to elastic, this was combined. The client is now defined in elastic.setup.py
1. print() removed with basic logging
All print() statements got removed by the base logger.
Appropriate levels were set. The default level is WARNING, defined in main.py
