### PR TITLE
Fixed search issue. rm es_client in get_es_indices()

### DIFF
--- a/src/search.py
+++ b/src/search.py
@@ -70,7 +70,7 @@ def _search_in_files(searchterm, found_terms, filter_query, exclude_fields):
     '''
     Searches the searchterm inside supported text files
     '''
-    es_indices = get_es_indices(es_client)
+    es_indices = get_es_indices()
     search_indices = []
     if 'pdf' in es_indices:
         search_indices.append('pdf')


### PR DESCRIPTION
es_client was given as parameter to get_es_indices in search.py.
With pull request #10 es_client got reorganizes to act globally, so parameter fell 