### PR TITLE
Use more es hosts

### DIFF
--- a/doc/Docker/UsingDockerCompose.md
+++ b/doc/Docker/UsingDockerCompose.md
@@ -5,7 +5,7 @@ This file is based on the Elasticsearch *docker-compose.yml* file from their ins
 ## Docker networking
 For docfex to be able to communicate with Elasticsearch, a docker network called *docfex-net* is defined for the first Elasticsearch container, and used again by docfex. This allows both containers to communicate.
 
-**Note:** The es_host inside *config.py* must be set to the containername defined for the first Elasticsearch container (*elastic* in this example). Otherwise docfex can't connect to Elasticsearch.
+**Note:** es_hosts list inside *config.py* must include containernames defined for the first Elasticsearch containers (*elastic* and *elastic2* in this example). Otherwise docfex can't connect to Elasticsearch.
 
 For more info on docker networking, see [Docker Networking](https://docs.docker.com/network/)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,6 @@ services:
     ports:
       - 9200:9200
     networks:
-      - esnet
       - docfex-net
   elastic2:
     image: manuelhatzl/elasticsearch_ingestattachment:6.7.1
@@ -35,7 +34,7 @@ services:
     volumes:
       - esdata2:/usr/share/elasticsearch/data
     networks:
-      - esnet
+      - docfex-net
   docfex:
     image: manuelhatzl/docfex:latest
     container_name: docfex
@@ -57,5 +56,4 @@ volumes:
     driver: local
 
 networks:
-  esnet:
   docfex-net:

--- a/src/app.py
+++ b/src/app.py
@@ -1,7 +1,7 @@
 from flask import render_template, Markup, send_from_directory, url_for, session, request, abort, current_app
 from elasticsearch_dsl.connections import connections
 from elasticsearch_dsl import Search
-from src.config.config import base_path, dir_breaks, SECRET_KEY, recent_topic_len, es_host, es_port, flask_hostname, flask_port, root_web_path, file_upload_path
+from src.config.config import base_path, dir_breaks, SECRET_KEY, recent_topic_len, flask_hostname, flask_port, root_web_path, file_upload_path
 from src.topics import topics, folder_group, file_group
 from src.elastic.setup import ElasticSettings, es_client
 from src.elastic.sync import sync_elastic

--- a/src/config/config.py.example
+++ b/src/config/config.py.example
@@ -45,7 +45,7 @@ recent_topic_len = 5
 # Host and port to connect to elasticsearch
 # When using docker, set es_host = <container name of elastic>
 # Note: A docker bridge network must be created to connect elastic with flask
-es_host = 'localhost'
+es_hosts = ['localhost']
 es_port = 9200
 
 # Define how often elastic gets synced with the os [min]

--- a/src/config/config.py.example
+++ b/src/config/config.py.example
@@ -43,7 +43,7 @@ recent_topic_len = 5
 #######################################################################################################
 
 # Host and port to connect to elasticsearch
-# When using docker, set es_host = <container name of elastic>
+# When using docker, set es_hosts = ['<container name of elastic>','<every additionaö elastic container>']
 # Note: A docker bridge network must be created to connect elastic with flask
 es_hosts = ['localhost']
 es_port = 9200

--- a/src/elastic/setup.py
+++ b/src/elastic/setup.py
@@ -3,13 +3,13 @@ from elasticsearch_dsl.connections import connections
 from elasticsearch.exceptions import TransportError
 from urllib3.exceptions import NewConnectionError
 from elasticsearch.client.cat import CatClient
-from src.config.config import es_host, es_port
+from src.config.config import es_hosts, es_port
 import logging
 import sys
 import time 
 
 used_es_indices = ['markdown', 'pdf', 'audio', 'video', 'folder']
-es_client = connections.create_connection(host=es_host, port=es_port, timeout=60)
+es_client = connections.create_connection(hosts=es_hosts, port=es_port, timeout=60)
 
 class ElasticSettings:
     '''


### PR DESCRIPTION
Updated elastic connection so it is possible to use more elastic hosts.
es_host renamed to es_hosts
es_hosts is now a list of elastic hosts

docker-compose updated to use both elastic services.
esnet removed. Everything goes over docfex-net