### PR TITLE
Recent keyerror

### DIFF
--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -2,7 +2,7 @@
 Docfex is in early development, so any kind of contribution is welcome.
 
 ## Code style
-* Try to adhere to the SOLID principles and keep your code DRY.
+* Try to keep your code DRY.
 * Name variables, functions and classes so they are self explanatory and need no comments.
 * Functions and classes used in more than one file must be commented.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The backend is using python [Flask](http://flask.pocoo.org/) and [Elasticsearch-
 
 
 ## Installation
-Docfex needs access to a Elasticsearch database. If you already have one setup
+Docfex needs access to Redis and a Elasticsearch database. If you already have those setup
 , you can skip the part to setup Elasticsearch.
 
 **Note:** Docfex will create indeces to store its document as soon as you start docfex!
@@ -24,7 +24,7 @@ sudo docker-compose up
 
 **Note:** For more information on running docfex using *docker-compose*, see [using docker-compose](doc/Docker/UsingDockerCompose.md).
 
-**Note:** Docfex can also be installed by simply creating an elastic and one docfex docker container.
+**Note:** Docfex can also be installed by simply creating one elastic, one redis and one docfex docker container.
 For more on running docfex using docker containers, see [using docker containers](doc/Docker/UsingContainers.md).
 
 

--- a/doc/Docker/UsingDockerCompose.md
+++ b/doc/Docker/UsingDockerCompose.md
@@ -3,9 +3,9 @@ Docfex can be started using the [docker-compose.yml](../../docker-compose.yml) f
 This file is based on the Elasticsearch *docker-compose.yml* file from their installation instructions found [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html).
 
 ## Docker networking
-For docfex to be able to communicate with Elasticsearch, a docker network called *docfex-net* is defined for the first Elasticsearch container, and used again by docfex. This allows both containers to communicate.
+For docfex to be able to communicate with Elasticsearch and Redis, a docker network called *docfex-net* is defined. This allows all containers to communicate.
 
-**Note:** es_hosts list inside *config.py* must include containernames defined for the first Elasticsearch containers (*elastic* and *elastic2* in this example). Otherwise docfex can't connect to Elasticsearch.
+**Note:** es_hosts list inside *config.py* must include containernames defined for the Elasticsearch containers (*elastic* and *elastic2* in this example). Otherwise docfex can't connect to Elasticsearch.
 
 For more info on docker networking, see [Docker Networking](https://docs.docker.com/network/)
 
@@ -15,7 +15,7 @@ In this docker-compose file, the image from [manuelhatzl/elasticsearch_ingestatt
 
 Since docfex should be able to handle big pdfs, the environment settings for Elasticsearch were also increased.
 For that, the heap size was increased by changing the JVM options *-Xms* and *-Xmx* from 512 MB to 2 GB respectively. 
-Additionally, also the maximal http content lenght was increased to 1.7 GB to be able to send large files.
+Additionally, also the maximal http content lenght was increased to 1700 MB to be able to send large files.
 
 **Note:** Per default, both Elasticsearch services store their values in docker volumes.
 If this is not wanted, you must change the service volumes for both services to bind mount.
@@ -25,10 +25,13 @@ An example of a bind mount can be seen in the docfex service.
 Docfex was tested with around 1000 pdfs with pdfs up to 500 MB of size. In this case, the heap size had to be increased to 10 GB.
 (This was tested on a single node!) 
 
+## Configuring the Redis service
+As described in [UsingContainers.md](UsingContainers.md), Redis is used as session interface for Flask.
+For that, a Redis service must be added that has access to the docfex-net network. The URL to the Redis service must be set in *config.py*, otherwise Flask can't store session informations.
 
 ## Configuring the Docfex service
 Docfex is the service that runs the Flask part and synchronises Elasticsearch with the given base path on the OS.
-As it depends on Elasticsearch to be available, the container will be started after both Elasticsearch containers are running.
+As it depends on Elasticsearch and Redis to be available, the container will be started after both Elasticsearch containers and Redis are running.
 
 **Note:** As described in the docker-compose reference documentation [here](https://docs.docker.com/compose/compose-file/)
 , *depend_on* is not waiting for a program inside a container to be ready, so docfex will return connection errors at first!

--- a/doc/Installation/InstallFromSource.md
+++ b/doc/Installation/InstallFromSource.md
@@ -1,7 +1,8 @@
 # Installing docfex from source
 Docfex requires a Elasticsearch database to be reachable. You can define the connection to Elastic inside [config.py](/src/config/config.py.example). Since private credentials are stored inside config.py you need to create it yourself. A template is given as [config.py.example](/src/config/config.py.example).
 
-**Note:** Makre sure Elasticsearch is reachable before starting docfex.
+**Note:** Make sure Elasticsearch is reachable before starting docfex.
+**Note:** Make sure Redis is reachable before starting docfex
 
 **Note:** When installing docfex from source, you need to have at least python **3.7.1** installed!
 Otherwise you won't be able to run it!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,11 +49,21 @@ services:
     depends_on:
       - elastic
       - elastic2
+      - redis      
     volumes:
       - /home/mhatzl/docfex/config:/opt/docfex/src/config
       - /home/mhatzl/Documents/BigDir:/mnt/basepath
     ports:
       - 5000:5000
+    networks:
+      - docfex-net
+
+  redis:
+    image: redis:latest
+    container_name: redis
+    restart: always
+    expose:
+      - 6379
     networks:
       - docfex-net
 

--- a/main.py
+++ b/main.py
@@ -18,7 +18,8 @@ def start_server(flask_debug=False):
     '''
     Starts docfex
     '''
-    logging.basicConfig(level=logging.WARNING)
+    logging.basicConfig(level=logging.INFO)
+    logging.info("Starting docfex ...")
     start_elastic()
     with app.app_context():
         start_flask(debug=flask_debug)
@@ -28,6 +29,7 @@ def start_elastic():
     '''
     Connects to elastic and creates a background job to kepp elastic and os in sync
     '''
+    logging.info("Accessing elasticsearch ...")
     setup_elastic()
     # omitting a trigger removes the job from the job pool, but interval trigger first waits for the interval to finish before execution
     # => using cron first, then reschedule to interval to start job immediately  

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,5 @@ urllib3>=1.25.3
 Werkzeug>=0.15.5
 wrapt>=1.11.2
 pygments>=2.4.2
+redis>=3.3.6
+flask_session>=0.3.1

--- a/src/app.py
+++ b/src/app.py
@@ -25,11 +25,13 @@ def start_flask(debug=False):
     Registers all request functions and starts the flask-app.
     Runs flask_shutdown() when flask is shutdown
     '''
+    logging.info("Starting flask ...")
     app = current_app._get_current_object()
     app.secret_key = SECRET_KEY
     app.static_folder = 'src/static'
     app.template_folder = 'src/templates'
-    app.before_first_request(bef_first_request)
+    app.before_request(before_request)
+    app.add_url_rule(root_web_path + 'favicon.ico', 'favicon', favicon)
     app.add_url_rule(root_web_path, 'home', home)
     app.add_url_rule(root_web_path + file_upload_path + '/<path:file_and_path>', 'get_local_file', get_local_file)
     app.add_url_rule(root_web_path + 'fakeEmbed/<path:file_and_path>', 'get_embed_file', get_embed_file)
@@ -44,6 +46,11 @@ def start_flask(debug=False):
         pass
     finally:    
         flask_shutdown()
+
+
+def favicon():
+    app = current_app._get_current_object()
+    return send_from_directory(app.static_folder, 'favicon.ico', mimetype='image/vnd.microsoft.icon')
 
 
 def flask_shutdown():
@@ -79,9 +86,9 @@ def remove_from_recent_topics():
     del(session['recent'][-1])         
 
 
-def bef_first_request():
+def before_request():
     '''
-    Defines actions that are run before the first request
+    Defines actions that are run before the every request
     '''
     session.permanent = True
     if not('settings' in session):
@@ -94,7 +101,8 @@ def bef_first_request():
             }
     if not('recent' in session):
         session['recent'] = []
-    
+
+
 
 def is_path_valid(path):
     '''

--- a/src/config/config.py.example
+++ b/src/config/config.py.example
@@ -14,6 +14,14 @@ dir_breaks = '/'
 
 
 #######################################################################################################
+#                               Redis settings
+#######################################################################################################
+
+# Define URL of Redis used for Flask sessions
+REDIS_URL = 'redis://redis:6379'
+
+
+#######################################################################################################
 #                               Flask settings
 #######################################################################################################
 
@@ -32,7 +40,7 @@ root_web_path = '/'
 file_upload_path = 'fakeUpload'
 
 # Secret key flask uses for session cookies
-SECRET_KEY = r'<generate e.g. with "os.urandom(24)>"'
+FLASK_SECRET_KEY = r'<generate e.g. with "os.urandom(24)>"'
 
 # Define number of elements displayed in the recent section on the mainapge
 recent_topic_len = 5

--- a/src/flasksession.py
+++ b/src/flasksession.py
@@ -1,0 +1,10 @@
+from src.config.config import FLASK_SECRET_KEY, REDIS_URL
+import redis
+
+# Flask session settings
+class SessionConfig(object):
+    SECRET_KEY = FLASK_SECRET_KEY
+    SESSION_TYPE = 'redis'
+    SESSION_REDIS = redis.from_url(REDIS_URL)
+    SESSION_PERMANENT = True
+    SESSION_KEY_PREFIX = 'DOCFEX'


### PR DESCRIPTION
Flask only stores session information on the first client that connects. All others will crash since needed information is stored in the session dictionary.
Redis had to be used as session interface for Flask.
-> Updated documentation accordingly

Fixes #16 